### PR TITLE
GEARBOx Data and Software updates page

### DIFF
--- a/docs/GEARBOxDataAndSoftwareUpdates.md
+++ b/docs/GEARBOxDataAndSoftwareUpdates.md
@@ -1,0 +1,5 @@
+# Gearbox Data and Software Updates
+| Version | Release Date   | Description |
+| ------- | -------------- | ----------------------------|
+| v1.2.0 | Dec 05, 2023 | Addition of four clinical trials for neuroblastoma and germ cell tumors |
+| v1.1.0 | Dec 06, 2022 | Addition of two clinical trials for AML |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,9 @@
 site_name: D4CG Documentation
 nav:
   - Privacy Notice: 'PcdcPrivacyNotice.md'
-  - GEARBOx Terms and Conditions: 'GEARBOxTermsandConditions.md'
+  - 'GEARBOx Documentation':
+    - GEARBOx Terms and Conditions: 'GEARBOxTermsandConditions.md'
+    - Data and Software Updates: 'GEARBOxDataAndSoftwareUpdates'
   - 'PCDC Documentation':
     - Acceptable Use Policy: 'AcceptableUsePolicy.md'
     - Statistical Manual: 'StatisticalManual.md'


### PR DESCRIPTION
Adding a new page to the documentation site showing GEARBOx release information. Also added to .yml file and added GEARBOx docs to a subsection of its own within the documentation page.