### PR TITLE
PEDS-1633 Bump cinotify/github-action from v1.1.0 to v1.6.0

### DIFF
--- a/.github/workflows/documentNotifications.yml
+++ b/.github/workflows/documentNotifications.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Send notification email
         if: steps.changed.outputs.files != '' && steps.changed.outputs.files != 'null'
-        uses: cinotify/github-action@v1.1.0
+        uses: cinotify/github-action@v1.6.0
         with:
           to: ${{ env.EMAIL_RECIPIENTS }}
           subject: Documentation Updated


### PR DESCRIPTION
v1.1.0 runs on the deprecated Node 12 actions runtime; v1.6.0 uses Node 20. Same inputs/outputs, no other changes needed.